### PR TITLE
feat: Implement Rule Properties Editing (Ports/Protocols) and Aggregated Edge View

### DIFF
--- a/my-visual-editor/package-lock.json
+++ b/my-visual-editor/package-lock.json
@@ -11,12 +11,14 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "reactflow": "^11.11.4",
+        "uuid": "^11.1.0",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
+        "@types/uuid": "^10.0.0",
         "@vitejs/plugin-react": "^4.3.4",
         "eslint": "^9.22.0",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -1944,6 +1946,13 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.31.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.0.tgz",
@@ -3821,6 +3830,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/my-visual-editor/package.json
+++ b/my-visual-editor/package.json
@@ -13,12 +13,14 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "reactflow": "^11.11.4",
+    "uuid": "^11.1.0",
     "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
+    "@types/uuid": "^10.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "eslint": "^9.22.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/my-visual-editor/src/features/Canvas/Canvas.tsx
+++ b/my-visual-editor/src/features/Canvas/Canvas.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useEffect } from 'react';
+import React, { useCallback, useRef, useEffect, useState } from 'react';
 import ReactFlow, {
   Node,
   Edge,
@@ -18,7 +18,7 @@ import { useAppStore } from '../../store/store';
 import CustomNodeNamespace from '../Nodes/CustomNodeNamespace';
 import CustomNodePodGroup from '../Nodes/CustomNodePodGroup';
 import CustomRuleEdge from '../Edges/CustomRuleEdge';
-import { type PodGroupNodeData } from '../Inspector/PodGroupPropertiesEditor';
+import { type PodGroupNodeData } from '../../types';
 
 type CanvasNodeData = PodGroupNodeData | { label?: string };
 
@@ -28,12 +28,91 @@ const edgeTypes = { customRuleEdge: CustomRuleEdge };
 let idCounter = 0;
 const getId = (prefix = 'dndnode') => `${prefix}_${idCounter++}`;
 
+const getAggregatedEdges = (inputEdges: Edge[]): Edge[] => {
+  console.log('[getAggregatedEdges] Input edges count:', inputEdges.length, 'Content:', JSON.parse(JSON.stringify(inputEdges)));
+  
+  const customRuleEdges: Edge[] = [];
+  const otherEdges: Edge[] = [];
+
+  // 1. Разделяем ребра на customRuleEdge и остальные
+  inputEdges.forEach(edge => {
+    if (edge.type === 'customRuleEdge') {
+      customRuleEdges.push(edge);
+    } else {
+      otherEdges.push(edge);
+    }
+  });
+
+  const edgeGroups = new Map<string, Edge[]>();
+
+  // 2. Группируем ТОЛЬКО customRuleEdge ребра
+  customRuleEdges.forEach(edge => {
+    const groupId = `${edge.source}-${edge.target}-${edge.sourceHandle || 'null'}-${edge.targetHandle || 'null'}`;
+    if (!edgeGroups.has(groupId)) {
+      edgeGroups.set(groupId, []);
+    }
+    edgeGroups.get(groupId)!.push(edge);
+  });
+
+  const processedCustomRuleEdges: Edge[] = [];
+
+  // 3. Обрабатываем сгруппированные customRuleEdge ребра
+  edgeGroups.forEach(group => {
+    if (group.length > 1) {
+      const representativeEdge = { ...group[0] };
+      const originalEdgeIds = group.map(e => e.id);
+      representativeEdge.data = {
+        ...representativeEdge.data,
+        isAggregated: true,
+        aggregatedCount: group.length,
+        originalEdgeIds: originalEdgeIds,
+      };
+      representativeEdge.label = `(${group.length}) Rules`;
+
+      processedCustomRuleEdges.push(representativeEdge);
+      group.slice(1).forEach(edgeInGroup => {
+        processedCustomRuleEdges.push({ ...edgeInGroup, hidden: true });
+      });
+    } else if (group.length === 1) {
+      const singleEdge = { ...group[0] };
+      singleEdge.data = {
+        ...singleEdge.data,
+        isAggregated: false,
+        aggregatedCount: 1,
+        originalEdgeIds: [singleEdge.id],
+      };
+      processedCustomRuleEdges.push(singleEdge);
+    }
+  });
+
+  // 4. Объединяем обработанные customRuleEdges с остальными ребрами
+  const finalEdges = [...processedCustomRuleEdges, ...otherEdges];
+  
+  console.log('[getAggregatedEdges] Final (processed) edges for React Flow count:', finalEdges.length, 'Content:', JSON.parse(JSON.stringify(finalEdges)));
+  return finalEdges;
+};
+
+
 const CanvasComponent: React.FC = () => {
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const reactFlowInstance = useReactFlow();
 
+  const [processedEdges, setProcessedEdges] = useState<Edge[]>([]);
+
   const nodes = useAppStore((state) => state.nodes as Node<CanvasNodeData>[]);
-  const edges = useAppStore((state) => state.edges);
+  const allEdgesDirectly = useAppStore.getState().edges;
+  console.log('[CanvasComponent] allEdgesDirectly from getState():', JSON.parse(JSON.stringify(allEdgesDirectly)));
+
+  const rawEdgesFromStore = useAppStore((state) => state.edges);
+  
+  useEffect(() => {
+    console.log('!!! CanvasComponent RENDERED or rawEdgesFromStore CHANGED !!!');
+    console.log('[useEffect for edges] rawEdgesFromStore count:', rawEdgesFromStore.length, 'Content:', JSON.parse(JSON.stringify(rawEdgesFromStore)));
+    const newProcessedEdges = getAggregatedEdges(rawEdgesFromStore);
+    console.log('[useEffect for edges] newProcessedEdges from getAggregatedEdges count:', newProcessedEdges.length, 'Content:', JSON.parse(JSON.stringify(newProcessedEdges)));
+    setProcessedEdges(newProcessedEdges);
+  }, [rawEdgesFromStore]);
+
   const onNodesChange = useAppStore((state) => state.onNodesChange as OnNodesChange);
   const onEdgesChange = useAppStore((state) => state.onEdgesChange as OnEdgesChange);
   const onConnect = useAppStore((state) => state.onConnect as (params: Connection | Edge) => void);
@@ -52,35 +131,24 @@ const CanvasComponent: React.FC = () => {
   const onDrop = useCallback(
     (event: React.DragEvent) => {
       event.preventDefault();
-      console.log('onDrop triggered');
-
       const type = event.dataTransfer.getData('application/reactflow');
-      if (!type || !reactFlowWrapper.current) {
-        console.log('onDrop: No type or wrapper, exiting.');
-        return;
-      }
+      if (!type || !reactFlowWrapper.current) return;
 
       const position = reactFlowInstance.screenToFlowPosition({ x: event.clientX, y: event.clientY });
-      console.log('onDrop: Drop position (flow coordinates):', position);
-
       let parentNodeId: string | undefined = undefined;
       let extent: 'parent' | undefined = undefined;
       let relativePosition = { ...position };
       let parentNSLabel: string | undefined = undefined;
 
       if (type === 'podGroup') {
-        const currentFlowNodes = reactFlowInstance.getNodes();
-        const potentialParent = currentFlowNodes
+        const potentialParent = reactFlowInstance.getNodes()
           .slice().reverse()
           .find(n =>
-            n.type === 'namespace' &&
-            n.positionAbsolute && n.width && n.height &&
+            n.type === 'namespace' && n.positionAbsolute && n.width && n.height &&
             position.x >= n.positionAbsolute.x && position.x <= n.positionAbsolute.x + n.width &&
             position.y >= n.positionAbsolute.y && position.y <= n.positionAbsolute.y + n.height
           );
-
         if (potentialParent) {
-          console.log('onDrop: Found potential parent namespace:', JSON.parse(JSON.stringify(potentialParent)));
           parentNodeId = potentialParent.id;
           extent = 'parent';
           if (potentialParent.positionAbsolute) {
@@ -88,78 +156,87 @@ const CanvasComponent: React.FC = () => {
               x: position.x - potentialParent.positionAbsolute.x,
               y: position.y - potentialParent.positionAbsolute.y,
             };
-          } else {
-            console.error('onDrop: Parent node has no positionAbsolute!', potentialParent.id);
           }
           parentNSLabel = (potentialParent.data as { label?: string })?.label;
-          console.log('onDrop: Calculated relativePosition:', relativePosition, 'Parent NS Label:', parentNSLabel);
-        } else {
-          console.log('onDrop: No parent namespace found for podGroup.');
         }
       }
 
       const newNodeId = getId(type);
-      const idSuffix = newNodeId.substring(newNodeId.lastIndexOf('_') + 1);
+      const defaultName = `${type}-${newNodeId.substring(newNodeId.lastIndexOf('_') + 1)}`;
+      const newNodeData: CanvasNodeData = type === 'podGroup'
+        ? {
+            label: defaultName,
+            labels: {},
+            metadata: { name: defaultName, namespace: parentNSLabel || '' },
+            policyConfig: { defaultDenyIngress: false, defaultDenyEgress: false },
+          }
+        : { label: defaultName };
 
-      const defaultName = type === 'podGroup' ? `pod-group-${idSuffix}` : `${type}-${idSuffix}`;
-
-      const newNodeData: CanvasNodeData =
-        type === 'podGroup'
-          ? {
-              label: defaultName,
-              labels: {},
-              metadata: { name: defaultName, namespace: parentNSLabel || '' },
-              policyConfig: { defaultDenyIngress: false, defaultDenyEgress: false },
-            }
-          : { label: defaultName };
-
-      const newNode: Node<CanvasNodeData> = {
-        id: newNodeId,
-        type,
-        position: relativePosition,
-        data: newNodeData,
-        parentNode: parentNodeId,
-        extent: extent,
-      };
-      console.log('onDrop: Creating new node:', JSON.parse(JSON.stringify(newNode)));
-
-      addNode(newNode);
-      console.log('onDrop: Node addition requested to store.');
+      addNode({
+        id: newNodeId, type, position: relativePosition, data: newNodeData,
+        parentNode: parentNodeId, extent: extent,
+      });
     },
     [reactFlowInstance, addNode]
   );
+
+  const handleNodeClick = useCallback((_: React.MouseEvent, node: Node) => setSelectedElementId(node.id), [setSelectedElementId]);
+  const handleEdgeClick = useCallback((_: React.MouseEvent, edge: Edge) => setSelectedElementId(edge.id), [setSelectedElementId]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!selectedElementId || (event.key !== 'Delete' && event.key !== 'Backspace')) return;
 
+      if (event.target instanceof HTMLElement && ['INPUT', 'TEXTAREA', 'SELECT'].includes(event.target.tagName)) {
+        return;
+      }
+
       const nodeToRemove = reactFlowInstance.getNode(selectedElementId);
       if (nodeToRemove) {
-        let nodesToDelete: Node<CanvasNodeData>[] = [nodeToRemove as Node<CanvasNodeData>];
+        let nodesToDeleteIds: string[] = [nodeToRemove.id];
         if (nodeToRemove.type === 'namespace') {
-          const childNodes = reactFlowInstance.getNodes()
+          const childNodeIds = reactFlowInstance.getNodes()
             .filter(n => n.parentNode === selectedElementId)
-            .map(n => n as Node<CanvasNodeData>);
-          nodesToDelete = [...nodesToDelete, ...childNodes];
+            .map(n => n.id);
+          nodesToDeleteIds = [...nodesToDeleteIds, ...childNodeIds];
         }
-        deleteElements({ nodes: nodesToDelete });
+        const nodesToDeleteObjects = nodesToDeleteIds.map(id => reactFlowInstance.getNode(id)).filter(Boolean) as Node[];
+        if (nodesToDeleteObjects.length > 0) {
+            deleteElements({ nodes: nodesToDeleteObjects });
+        }
+
       } else {
-        const edgeToRemove = reactFlowInstance.getEdge(selectedElementId);
+        const edgeToRemove = processedEdges.find(e => e.id === selectedElementId && !e.hidden);
         if (edgeToRemove) {
-             deleteElements({ edges: [edgeToRemove] });
+            const nodeAlsoSelected = reactFlowInstance.getNode(selectedElementId);
+            if(nodeAlsoSelected) return;
+
+            let edgesToDeleteFromStore: Edge[] = [];
+            if (edgeToRemove.data?.isAggregated && edgeToRemove.data?.originalEdgeIds) {
+                edgesToDeleteFromStore = (edgeToRemove.data.originalEdgeIds as string[])
+                    .map(id => rawEdgesFromStore.find(e => e.id === id))
+                    .filter(Boolean) as Edge[];
+            } else if (!edgeToRemove.data?.isAggregated) {
+                const originalEdge = rawEdgesFromStore.find(e => e.id === edgeToRemove.id);
+                if (originalEdge) edgesToDeleteFromStore = [originalEdge];
+            }
+
+            if (edgesToDeleteFromStore.length > 0) {
+                 console.log('[Delete] Deleting edges from store:', edgesToDeleteFromStore.map(e=>e.id));
+                 deleteElements({ edges: edgesToDeleteFromStore });
+            }
         }
       }
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [selectedElementId, deleteElements, reactFlowInstance]);
-
+  }, [selectedElementId, deleteElements, reactFlowInstance, rawEdgesFromStore, processedEdges, nodes])
 
   return (
     <div className="reactflow-wrapper" ref={reactFlowWrapper} style={{ width: '100%', height: '100%' }}>
       <ReactFlow
         nodes={nodes}
-        edges={edges}
+        edges={processedEdges}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onConnect={onConnect}
@@ -168,13 +245,15 @@ const CanvasComponent: React.FC = () => {
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         onPaneClick={handlePaneClick}
+        onNodeClick={handleNodeClick}
+        onEdgeClick={handleEdgeClick}
         deleteKeyCode={null}
         fitView
         nodesDraggable={true}
         nodesConnectable={true}
       >
         <Controls />
-        <MiniMap nodeStrokeWidth={3} />
+        <MiniMap nodeStrokeWidth={3} zoomable pannable />
         <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
       </ReactFlow>
     </div>

--- a/my-visual-editor/src/features/Edges/CustomRuleEdge.tsx
+++ b/my-visual-editor/src/features/Edges/CustomRuleEdge.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { EdgeProps, getBezierPath, EdgeLabelRenderer, BaseEdge } from 'reactflow';
 
 const CustomRuleEdge: React.FC<EdgeProps> = ({
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-  id,
   sourceX,
   sourceY,
   targetX,
@@ -13,6 +11,7 @@ const CustomRuleEdge: React.FC<EdgeProps> = ({
   style = {},
   markerEnd,
   data,
+  label,
 }) => {
   const [edgePath, labelX, labelY] = getBezierPath({
     sourceX,
@@ -23,22 +22,34 @@ const CustomRuleEdge: React.FC<EdgeProps> = ({
     targetPosition,
   });
 
+  let displayLabel: React.ReactNode = null;
+  if (label) {
+    displayLabel = label;
+  } else if (data?.ruleApplied) {
+    displayLabel = `Rule: ${data.ruleApplied}`;
+  }
+
   return (
     <>
       <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />
-      <EdgeLabelRenderer>
-        <div
-          style={{
-            position: 'absolute',
-            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
-            fontSize: 10,
-            pointerEvents: 'all',
-          }}
-          className="nodrag nopan"
-        >
-          {data?.ruleApplied && `Rule: ${data.ruleApplied}`}
-        </div>
-      </EdgeLabelRenderer>
+      {displayLabel && (
+        <EdgeLabelRenderer>
+          <div
+            style={{
+              position: 'absolute',
+              transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+              fontSize: 10,
+              backgroundColor: 'rgba(255, 255, 255, 0.7)',
+              padding: '2px 4px',
+              borderRadius: '3px',
+              pointerEvents: 'all',
+            }}
+            className="nodrag nopan"
+          >
+            {displayLabel}
+          </div>
+        </EdgeLabelRenderer>
+      )}
     </>
   );
 };

--- a/my-visual-editor/src/features/Inspector/InspectorView.css
+++ b/my-visual-editor/src/features/Inspector/InspectorView.css
@@ -159,3 +159,60 @@
   .add-label-form > div {
       margin-bottom: 10px;
   }
+
+.aggregated-rule-details {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #eee;
+}
+
+.aggregated-rule-details h4 {
+  margin-top: 0;
+  margin-bottom: 10px;
+  font-size: 1.05em;
+  color: #444;
+}
+
+.aggregated-rule-details p {
+  margin-bottom: 8px;
+  font-size: 0.95em;
+}
+
+.aggregated-rule-details ul {
+  list-style: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.aggregated-rule-details li button {
+  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  padding: 6px 12px;
+  margin-bottom: 6px;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  border-radius: 4px;
+  font-size: 0.9em;
+  color: #333;
+  transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
+}
+
+.aggregated-rule-details li button:hover {
+  background-color: #e0e0e0;
+  border-color: #bbb;
+}
+
+.aggregated-rule-details li button.active {
+  background-color: #007bff;
+  color: white;
+  border-color: #007bff;
+  font-weight: bold;
+}
+
+.aggregated-rule-details hr {
+    border: 0;
+    border-top: 1px solid #eee;
+    margin: 15px 0;
+}

--- a/my-visual-editor/src/features/Inspector/InspectorView.tsx
+++ b/my-visual-editor/src/features/Inspector/InspectorView.tsx
@@ -1,33 +1,153 @@
-import React from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useAppStore } from '../../store/store';
-import PodGroupPropertiesEditor, { PodGroupNodeData } from './PodGroupPropertiesEditor';
+import PodGroupPropertiesEditor from './PodGroupPropertiesEditor';
 import NamespacePropertiesEditor from './NamespacePropertiesEditor';
-import { Node } from 'reactflow';
+import RulePortsEditor from './RulePortsEditor';
+import { PortProtocolEntry, PodGroupNodeData, isPodGroupNodeData, NamespaceNodeData } from '../../types';
+import { Node, Edge } from 'reactflow';
 import './InspectorView.css';
 
-interface NamespaceNodeData {
-  label?: string;
-}
+
+const getEdgeGroupId = (edge: Edge): string => {
+  return `${edge.source}-${edge.target}-${edge.sourceHandle || 'null'}-${edge.targetHandle || 'null'}`;
+};
 
 const InspectorView: React.FC = () => {
   const selectedElementId = useAppStore((state) => state.selectedElementId);
   const nodes = useAppStore((state) => state.nodes as Node<PodGroupNodeData | NamespaceNodeData>[]);
+  const allEdges = useAppStore((state) => state.edges);
+  const updateEdgeData = useAppStore((state) => state.updateEdgeData);
 
-  const selectedNode = nodes.find((node) => node.id === selectedElementId);
+  const [editingOriginalEdgeId, setEditingOriginalEdgeId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setEditingOriginalEdgeId(null);
+  }, [selectedElementId]);
+
+  const selectedNode = useMemo(() => {
+    if (!selectedElementId) return null;
+    return nodes.find((node) => node.id === selectedElementId);
+  }, [selectedElementId, nodes]);
+
+  const selectedEdgeInfo = useMemo(() => {
+    if (!selectedElementId) return null;
+    const directlySelectedEdge = allEdges.find(edge => edge.id === selectedElementId);
+    if (!directlySelectedEdge || directlySelectedEdge.type !== 'customRuleEdge') return { edge: directlySelectedEdge, isAggregated: false, originalEdgeIds: directlySelectedEdge ? [directlySelectedEdge.id] : [], aggregatedCount: 1 };
+    const groupId = getEdgeGroupId(directlySelectedEdge);
+    const group: Edge[] = [];
+    allEdges.forEach(e => {
+      if (e.type === 'customRuleEdge' && getEdgeGroupId(e) === groupId) {
+        group.push(e);
+      }
+    });
+    if (group.length > 1) {
+      const representativeInGroup = group.sort((a,b) => a.id.localeCompare(b.id))[0];
+      if (directlySelectedEdge.id === representativeInGroup.id) {
+        return {
+          edge: directlySelectedEdge,
+          isAggregated: true,
+          aggregatedCount: group.length,
+          originalEdgeIds: group.map(e => e.id).sort((a,b) => a.localeCompare(b)),
+        };
+      } else {
+         return { edge: directlySelectedEdge, isAggregated: false, originalEdgeIds: [directlySelectedEdge.id], aggregatedCount: 1 };
+      }
+    }
+    return { edge: directlySelectedEdge, isAggregated: false, originalEdgeIds: [directlySelectedEdge.id], aggregatedCount: 1 };
+  }, [selectedElementId, allEdges]);
+
+  console.log('[InspectorView] Selected Element ID:', selectedElementId);
+  console.log('[InspectorView] Calculated selectedEdgeInfo:', selectedEdgeInfo ? JSON.parse(JSON.stringify(selectedEdgeInfo)) : null);
+  if (selectedEdgeInfo?.edge) {
+      console.log('[InspectorView] selectedEdgeInfo.edge.data:', JSON.parse(JSON.stringify(selectedEdgeInfo.edge.data)));
+      console.log('[InspectorView] selectedEdgeInfo.isAggregated:', selectedEdgeInfo.isAggregated);
+  }
+
+
+  const edgeToEditDetails = editingOriginalEdgeId
+    ? allEdges.find(edge => edge.id === editingOriginalEdgeId)
+    : (selectedEdgeInfo?.isAggregated ? null : selectedEdgeInfo?.edge);
+
+  const handlePortsChange = (updatedPorts: PortProtocolEntry[], isValid: boolean) => {
+    const edgeIdToUpdate = editingOriginalEdgeId || (selectedEdgeInfo?.edge && !selectedEdgeInfo.isAggregated ? selectedEdgeInfo.edge.id : null);
+    if (edgeIdToUpdate) {
+      console.log(`Ports update for edge ${edgeIdToUpdate}. Valid:`, isValid);
+      updateEdgeData(edgeIdToUpdate, { ports: updatedPorts });
+    }
+  };
 
   return (
     <div className="inspector-view">
-      <h3>Inspector</h3>
-      {selectedNode ? (
-        selectedNode.type === 'podGroup' ? (
-          <PodGroupPropertiesEditor node={selectedNode as Node<PodGroupNodeData>} />
-        ) : selectedNode.type === 'namespace' ? (
-          <NamespacePropertiesEditor node={selectedNode as Node<NamespaceNodeData>} />
-        ) : (
-          <p>Selected element: {selectedNode.id} (Type: {selectedNode.type}). No editor available for this type.</p>
-        )
-      ) : (
-        <p>Select an element to see its properties.</p>
+      <h3>Свойства элемента</h3>
+      
+      {selectedNode && (
+        <>
+          <p>ID: {selectedNode.id}</p>
+          <p>Тип: {selectedNode.type}</p>
+          {selectedNode.type === 'namespace' && (
+            <NamespacePropertiesEditor
+              node={selectedNode as Node<NamespaceNodeData>}
+            />
+          )}
+          {selectedNode.type === 'podGroup' && isPodGroupNodeData(selectedNode.data) && (
+             <PodGroupPropertiesEditor
+              node={selectedNode as Node<PodGroupNodeData>}
+            />
+          )}
+           {selectedNode.type !== 'namespace' && selectedNode.type !== 'podGroup' && (
+             <p>Выбран элемент: {selectedNode.id} (Тип: {selectedNode.type}). Редактор для этого типа отсутствует.</p>
+           )}
+           <hr />
+        </>
+      )}
+
+
+      {selectedEdgeInfo?.edge && !selectedNode && (
+        <>
+          <p>ID: {selectedEdgeInfo.edge.id} (Тип: Ребро)</p>
+          <p>Источник: {selectedEdgeInfo.edge.source}</p>
+          <p>Назначение: {selectedEdgeInfo.edge.target}</p>
+
+          {selectedEdgeInfo.isAggregated ? (
+            <div className="aggregated-rule-details">
+              <h4>Агрегированное правило</h4>
+              <p>Это правило представляет {selectedEdgeInfo.aggregatedCount} индивидуальных правил.</p>
+              <p>Выберите правило для редактирования портов:</p>
+              <ul>
+                {(selectedEdgeInfo.originalEdgeIds as string[]).map((originalId) => (
+                  <li key={originalId}>
+                    <button
+                      onClick={() => setEditingOriginalEdgeId(originalId)}
+                      className={editingOriginalEdgeId === originalId ? 'active' : ''}
+                    >
+                      Редактировать ID: {originalId.slice(-6)}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              {editingOriginalEdgeId && <hr />}
+            </div>
+          ) : (
+            !editingOriginalEdgeId && <p>Простое правило:</p>
+          )}
+
+          {edgeToEditDetails && (
+             <>
+                {editingOriginalEdgeId && <p>Редактирование правила ID: {editingOriginalEdgeId.slice(-6)}</p>}
+                <RulePortsEditor
+                    ports={(edgeToEditDetails.data?.ports as PortProtocolEntry[] | undefined) || []}
+                    onChange={handlePortsChange}
+                />
+             </>
+          )}
+        </>
+      )}
+
+      {!selectedNode && !selectedEdgeInfo?.edge && selectedElementId && (
+          <p>Выбранный элемент с ID {selectedElementId} не найден или является скрытым ребром.</p>
+      )}
+       {!selectedElementId && (
+          <p>Выберите элемент для просмотра свойств.</p>
       )}
     </div>
   );

--- a/my-visual-editor/src/features/Inspector/NamespacePropertiesEditor.tsx
+++ b/my-visual-editor/src/features/Inspector/NamespacePropertiesEditor.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { Node } from 'reactflow';
+import { NamespaceNodeData } from '../../types';
 import { useAppStore } from '../../store/store';
-
-interface NamespaceNodeData {
-  label?: string;
-}
 
 interface NamespacePropertiesEditorProps {
   node: Node<NamespaceNodeData>;

--- a/my-visual-editor/src/features/Inspector/PodGroupPropertiesEditor.tsx
+++ b/my-visual-editor/src/features/Inspector/PodGroupPropertiesEditor.tsx
@@ -1,20 +1,7 @@
-// src/features/Inspector/PodGroupPropertiesEditor.tsx
 import React, { useState, useEffect } from 'react';
 import { Node } from 'reactflow';
 import { useAppStore } from '../../store/store';
-
-export interface PodGroupNodeData {
-  label?: string;
-  labels: Record<string, string>;
-  metadata: {
-    name: string;
-    namespace: string;
-  };
-  policyConfig: {
-    defaultDenyIngress: boolean;
-    defaultDenyEgress: boolean;
-  };
-}
+import { PodGroupNodeData } from '../../types';
 
 interface PodGroupPropertiesEditorProps {
   node: Node<PodGroupNodeData>;
@@ -73,7 +60,7 @@ const errorTextStyle: React.CSSProperties = {
 
 const inputErrorStyle: React.CSSProperties = {
   borderColor: 'red',
-  boxShadow: '0 0 0 1px rgba(255,0,0,.25)', // Уменьшил размытие для компактности
+  boxShadow: '0 0 0 1px rgba(255,0,0,.25)',
 };
 
 // --- Component ---

--- a/my-visual-editor/src/features/Inspector/RulePortsEditor.css
+++ b/my-visual-editor/src/features/Inspector/RulePortsEditor.css
@@ -1,0 +1,61 @@
+.port-protocol-entry {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.port-protocol-entry > div {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+.port-input {
+  padding: 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.protocol-select {
+  padding: 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.remove-button {
+  padding: 6px 10px;
+  background-color: #f44336;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.remove-button:hover {
+  background-color: #d32f2f;
+}
+
+.add-button {
+  padding: 8px 12px;
+  background-color: #4CAF50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 10px;
+}
+.add-button:hover {
+  background-color: #45a049;
+}
+
+.input-error {
+  border-color: red;
+  box-shadow: 0 0 0 1px rgba(255, 0, 0, 0.3);
+}
+
+.error-text {
+  color: red;
+  font-size: 0.85em;
+  margin-top: 4px;
+  margin-bottom: 0;
+}

--- a/my-visual-editor/src/features/Inspector/RulePortsEditor.tsx
+++ b/my-visual-editor/src/features/Inspector/RulePortsEditor.tsx
@@ -1,0 +1,148 @@
+import React, { useState, useEffect } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { PortProtocolEntry } from '../../types';
+import './RulePortsEditor.css';
+
+interface RulePortsEditorProps {
+  ports: PortProtocolEntry[];
+  onChange: (updatedPorts: PortProtocolEntry[], isValid: boolean) => void;
+}
+
+const validatePort = (port: string): string | null => {
+  if (!port.trim()) {
+    return 'Порт не может быть пустым.';
+  }
+  if (port.toLowerCase() === 'any') {
+    return null;
+  }
+  if (/^\d+$/.test(port)) {
+    const num = parseInt(port, 10);
+    if (num >= 1 && num <= 65535) {
+      return null;
+    }
+    return 'Порт должен быть числом от 1 до 65535.';
+  }
+  if (/^\d+-\d+$/.test(port)) {
+    const [startStr, endStr] = port.split('-');
+    const start = parseInt(startStr, 10);
+    const end = parseInt(endStr, 10);
+    if (
+      !isNaN(start) && !isNaN(end) &&
+      start >= 1 && start <= 65535 &&
+      end >= 1 && end <= 65535 &&
+      start < end
+    ) {
+      return null;
+    }
+    return 'Неверный диапазон портов (1-65535, начало < конца).';
+  }
+  return 'Неверный формат порта (e.g., 80, 100-200, any).';
+};
+
+const RulePortsEditor: React.FC<RulePortsEditorProps> = ({ ports = [], onChange }) => {
+  const [errors, setErrors] = useState<Record<string, string | null>>({});
+
+  const checkAllPortsValid = (currentPorts: PortProtocolEntry[]): boolean => {
+    let allValid = true;
+    const newErrors: Record<string, string | null> = {};
+    for (const entry of currentPorts) {
+      const error = validatePort(entry.port);
+      if (error) {
+        allValid = false;
+      }
+      newErrors[entry.id] = error;
+    }
+    setErrors(newErrors);
+    return allValid;
+  };
+
+  useEffect(() => {
+    checkAllPortsValid(ports);
+  }, [ports]);
+
+  const handleAddPortProtocol = () => {
+    const newEntry: PortProtocolEntry = {
+      id: uuidv4(),
+      port: '',
+      protocol: 'TCP',
+    };
+    const updatedPorts = [...ports, newEntry];
+    const isValid = checkAllPortsValid(updatedPorts);
+    onChange(updatedPorts, isValid);
+  };
+
+  const handlePortChange = (id: string, newPortValue: string) => {
+    const updatedPorts = ports.map((entry) =>
+      entry.id === id ? { ...entry, port: newPortValue } : entry
+    );
+    const error = validatePort(newPortValue);
+    setErrors(prevErrors => ({ ...prevErrors, [id]: error }));
+
+    const allValid = Object.values({...errors, [id]: error }).every(e => e === null) &&
+                     updatedPorts.every(p => validatePort(p.port) === null);
+
+    onChange(updatedPorts, allValid);
+  };
+
+  const handleProtocolChange = (id: string, newProtocol: PortProtocolEntry['protocol']) => {
+    const updatedPorts = ports.map((entry) =>
+      entry.id === id ? { ...entry, protocol: newProtocol } : entry
+    );
+    const allValid = checkAllPortsValid(updatedPorts);
+    onChange(updatedPorts, allValid);
+  };
+
+  const handleRemovePortProtocol = (id: string) => {
+    const updatedPorts = ports.filter((entry) => entry.id !== id);
+    const allValid = checkAllPortsValid(updatedPorts);
+    onChange(updatedPorts, allValid);
+  };
+
+  const stopPropagation = (e: React.KeyboardEvent) => { 
+    e.stopPropagation();
+  };
+
+
+  return (
+    <div className="rule-ports-editor">
+      <h4>Порты и Протоколы</h4>
+      {ports.map((entry) => (
+        <div key={entry.id} className="port-protocol-entry">
+          <div>
+            <input
+              type="text"
+              placeholder="Порт (e.g., 80, 100-200, any)"
+              value={entry.port}
+              onChange={(e) => handlePortChange(entry.id, e.target.value)}
+              onKeyDown={stopPropagation}
+              className={`port-input ${errors[entry.id] ? 'input-error' : ''}`}
+            />
+            {errors[entry.id] && <p className="error-text">{errors[entry.id]}</p>}
+          </div>
+          <select
+            value={entry.protocol}
+            onChange={(e) => handleProtocolChange(entry.id, e.target.value as PortProtocolEntry['protocol'])}
+            className="protocol-select"
+          >
+            <option value="TCP">TCP</option>
+            <option value="UDP">UDP</option>
+            <option value="SCTP">SCTP</option>
+            <option value="ICMP">ICMP</option>
+            <option value="ANY">ANY</option>
+          </select>
+          <button
+            onClick={() => handleRemovePortProtocol(entry.id)}
+            className="remove-button"
+          >
+            Удалить
+          </button>
+        </div>
+      ))}
+      <button onClick={handleAddPortProtocol} className="add-button">
+        Добавить порт/протокол
+      </button>
+    </div>
+  );
+};
+
+export default RulePortsEditor;

--- a/my-visual-editor/src/layout/Layout.tsx
+++ b/my-visual-editor/src/layout/Layout.tsx
@@ -3,10 +3,22 @@ import CanvasWrapper from '../features/Canvas/Canvas';
 import Palette from '../features/Palette/Palette';
 import InspectorView from '../features/Inspector/InspectorView';
 import './Layout.css';
+import { useAppStore } from '../store/store';
+
+const EdgeCounterDisplay: React.FC = () => {
+  const edgesCount = useAppStore((state) => state.edges.length);
+  console.log('[EdgeCounterDisplay] Edges count from store:', edgesCount);
+  return (
+    <div style={{ position: 'fixed', top: 0, right: 0, backgroundColor: 'rgba(200, 200, 200, 0.8)', padding: '5px 10px', zIndex: 10000, borderBottomLeftRadius: '5px' }}>
+      Edges in Store: {edgesCount}
+    </div>
+  );
+};
 
 const Layout: React.FC = () => {
   return (
     <div className="layout-container">
+      <EdgeCounterDisplay />
       <Palette />
 
       <div className="canvas-container">

--- a/my-visual-editor/src/types/index.ts
+++ b/my-visual-editor/src/types/index.ts
@@ -1,0 +1,42 @@
+export interface PortProtocolEntry {
+  id: string;
+  port: string;
+  protocol: 'TCP' | 'UDP' | 'SCTP' | 'ICMP' | 'ANY';
+}
+
+export interface PodGroupNodeData {
+      label?: string;
+      labels: Record<string, string>;
+      metadata: {
+        name: string;
+        namespace: string;
+      };
+      policyConfig: {
+        defaultDenyIngress: boolean;
+        defaultDenyEgress: boolean;
+      };
+    }
+
+export function isPodGroupNodeData(data: unknown): data is PodGroupNodeData {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+
+  const d = data as Partial<PodGroupNodeData>;
+
+  return (
+    typeof d.metadata === 'object' && d.metadata !== null &&
+    typeof d.metadata.name === 'string' &&
+    typeof d.metadata.namespace === 'string' &&
+
+    typeof d.policyConfig === 'object' && d.policyConfig !== null &&
+    typeof d.policyConfig.defaultDenyIngress === 'boolean' &&
+    typeof d.policyConfig.defaultDenyEgress === 'boolean' &&
+
+    typeof d.labels === 'object' && d.labels !== null
+  );
+}
+
+export interface NamespaceNodeData {
+  label?: string;
+}


### PR DESCRIPTION
This PR introduces the ability to edit port and protocol properties for rules (edges) directly within the InspectorView, including input validation. It also implements a basic visualization for aggregated edges on the canvas and provides a mechanism to edit the underlying individual rules from the inspector.

**Key Changes:**

*   **Edge Port/Protocol Editing:**
    *   Users can now add, edit, and remove port/protocol entries for a selected rule in the InspectorView.
    *   Input validation is in place for port fields (e.g., single port, range, "any").
    *   Changes to `ports` are updated in the `edge.data.ports` array in the Zustand store.
*   **Aggregated Edge Visualization:**
    *   Multiple rules between the same source/target nodes (and handles) are visually represented as a single edge on the canvas, displaying a label indicating the number of aggregated rules (e.g., "(2) Rules").
    *   Non-representative rules within an aggregated group are hidden.
*   **Aggregated Edge Editing Logic:**
    *   When an aggregated edge is selected, the InspectorView indicates that it's an aggregated rule.
    *   It then lists the original individual rules that form the aggregation.
    *   Users can select one of these original rules to edit its specific ports/protocols using the standard port editor.

Closes #8