### PR TITLE
feat: Implement NetworkPolicy YAML Generation Core Logic

### DIFF
--- a/my-visual-editor/src/App.css
+++ b/my-visual-editor/src/App.css
@@ -15,3 +15,15 @@ body {
   height: 100%;
   display: flex;
 }
+
+.react-flow__nodes {
+  z-index: 1 !important; 
+}
+
+.react-flow__edges {
+  z-index: 2 !important;
+}
+
+.react-flow__edgelabel-renderer {
+  z-index: 3 !important;
+}

--- a/my-visual-editor/src/features/Edges/CustomRuleEdge.tsx
+++ b/my-visual-editor/src/features/Edges/CustomRuleEdge.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { CSSProperties } from 'react';
 import { EdgeProps, getBezierPath, EdgeLabelRenderer, BaseEdge } from 'reactflow';
+
 
 const CustomRuleEdge: React.FC<EdgeProps> = ({
   sourceX,
@@ -26,12 +27,22 @@ const CustomRuleEdge: React.FC<EdgeProps> = ({
   if (label) {
     displayLabel = label;
   } else if (data?.ruleApplied) {
-    displayLabel = `Rule: ${data.ruleApplied}`;
+    const ruleText = typeof data.ruleApplied === 'string' ? data.ruleApplied : 'Rule';
+    displayLabel = ruleText.length > 20 ? `${ruleText.substring(0, 17)}...` : ruleText;
+    if (data.isAggregated && data.aggregatedCount > 1) {
+        displayLabel = `(${data.aggregatedCount}) ${displayLabel}`;
+    }
   }
+
+  const edgeStyle: CSSProperties = {
+    ...style,
+    zIndex: 1,
+  };
+
 
   return (
     <>
-      <BaseEdge path={edgePath} markerEnd={markerEnd} style={style} />
+      <BaseEdge path={edgePath} markerEnd={markerEnd} style={edgeStyle} />
       {displayLabel && (
         <EdgeLabelRenderer>
           <div
@@ -39,10 +50,12 @@ const CustomRuleEdge: React.FC<EdgeProps> = ({
               position: 'absolute',
               transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
               fontSize: 10,
-              backgroundColor: 'rgba(255, 255, 255, 0.7)',
-              padding: '2px 4px',
-              borderRadius: '3px',
+              zIndex: (style?.zIndex as number || 1) + 1,
+              backgroundColor: 'rgba(255, 255, 255, 0.8)',
+              padding: '2px 5px',
+              borderRadius: '4px',
               pointerEvents: 'all',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
             }}
             className="nodrag nopan"
           >

--- a/my-visual-editor/src/features/OutputView/OutputView.tsx
+++ b/my-visual-editor/src/features/OutputView/OutputView.tsx
@@ -1,16 +1,37 @@
 import React, { useState, useMemo } from 'react';
 import './OutputView.css';
 import { YamlGenerationService } from '../../services/YamlGenerationService';
+import { useAppStore } from '../../store/store';
+import { Node, Edge } from 'reactflow';
+import { PodGroupNodeData, NamespaceNodeData, isPodGroupNodeData } from '../../types';
 
 const OutputView: React.FC = () => {
   const [yamlOutput, setYamlOutput] = useState<string>('');
 
+  const selectedElementId = useAppStore((state) => state.selectedElementId);
+  const nodes = useAppStore((state) => state.nodes as Node<PodGroupNodeData | NamespaceNodeData>[]);
+  const edges = useAppStore((state) => state.edges as Edge[]);
+
   const yamlService = useMemo(() => new YamlGenerationService(), []);
 
-  const handleGenerateYaml = () => {
-    const generatedYaml = yamlService.generateYamlString();
+  const handleGenerateYaml = (): void => {
+    if (!selectedElementId) {
+      setYamlOutput("# Пожалуйста, выберите PodGroup на холсте для генерации NetworkPolicy.");
+      return;
+    }
+    const targetNode = nodes.find(node => node.id === selectedElementId);
+    if (!targetNode || targetNode.type !== 'podGroup' || !isPodGroupNodeData(targetNode.data)) {
+      setYamlOutput("# Выбранный элемент не является PodGroup или его данные некорректны.\n# NetworkPolicy может быть сгенерирована только для PodGroup.");
+      return;
+    }
+    if (!targetNode.data.metadata.namespace) {
+        setYamlOutput(`# Ошибка: У выбранного PodGroup '${targetNode.data.metadata.name || targetNode.id}' не указан неймспейс.\n# Пожалуйста, укажите неймспейс в свойствах PodGroup (Инспектор).`);
+        return;
+    }
+    const policyObject = yamlService.createNetworkPolicyObject(selectedElementId, nodes, edges);
+    const generatedYaml = yamlService.generateYamlString(policyObject);
+    
     setYamlOutput(generatedYaml);
-    console.log("Сгенерированный YAML:\n", generatedYaml);
   };
 
   return (
@@ -18,11 +39,11 @@ const OutputView: React.FC = () => {
       <h3>Сгенерированный YAML</h3>
       <div className="output-view-controls">
         <button onClick={handleGenerateYaml} className="generate-yaml-button">
-          Сгенерировать YAML
+          Сгенерировать YAML (для выбранного PodGroup)
         </button>
       </div>
       <pre className={`yaml-output-panel ${!yamlOutput ? 'placeholder' : ''}`}>
-        {yamlOutput || 'Нажмите "Сгенерировать YAML", чтобы увидеть результат.'}
+        {yamlOutput || 'Выберите PodGroup и нажмите "Сгенерировать YAML", чтобы увидеть результат.'}
       </pre>
     </div>
   );

--- a/my-visual-editor/src/services/YamlGenerationService.ts
+++ b/my-visual-editor/src/services/YamlGenerationService.ts
@@ -1,57 +1,211 @@
-import { v4 as uuidv4 } from 'uuid';
 import { dump } from 'js-yaml';
-
-interface NetworkPolicyMetadata {
-  name?: string;
-  namespace?: string;
-}
-
-interface PodSelector {
-  matchLabels?: { [key: string]: string };
-}
-
-interface NetworkPolicySpec {
-  podSelector: PodSelector;
-}
-
-export interface NetworkPolicy {
-  apiVersion: string;
-  kind: string;
-  metadata: NetworkPolicyMetadata;
-  spec: NetworkPolicySpec;
-}
+import { Node, Edge } from 'reactflow';
+import {
+  NetworkPolicy,
+  PodGroupNodeData,
+  NamespaceNodeData,
+  isPodGroupNodeData,
+  PolicyType,
+  NetworkPolicyIngressRule,
+  NetworkPolicyEgressRule,
+  NetworkPolicyPeer,
+  PortProtocolEntry,
+  NetworkPolicyPort,
+} from '../types';
 
 export class YamlGenerationService {
   constructor() {}
 
-  private generatePolicyName(): string {
-    const SuffixLength = 8;
-    const uniqueSuffix = uuidv4().substring(0, SuffixLength);
-    return `netpol-${uniqueSuffix}`;
+  private transformUiPortToK8sPort(uiPortEntry: PortProtocolEntry): NetworkPolicyPort | null {
+    const k8sPort: NetworkPolicyPort = {};
+
+    if (uiPortEntry.protocol && uiPortEntry.protocol !== 'ANY' && uiPortEntry.protocol !== 'ICMP') {
+      if (['TCP', 'UDP', 'SCTP'].includes(uiPortEntry.protocol)) {
+        k8sPort.protocol = uiPortEntry.protocol as 'TCP' | 'UDP' | 'SCTP';
+      } else {
+        console.warn(`[YamlGenSvc] Неподдерживаемый протокол '${uiPortEntry.protocol}' для NetworkPolicyPort, будет пропущен.`);
+      }
+    }
+
+    if (uiPortEntry.port && uiPortEntry.port.toLowerCase() !== 'any') {
+      if (/^\d+-\d+$/.test(uiPortEntry.port)) {
+        console.warn(`[YamlGenSvc] Диапазоны портов ('${uiPortEntry.port}') не поддерживаются стандартным NetworkPolicyPort. Это правило порта будет пропущено.`);
+        return null;
+      } else {
+        const numericPort = parseInt(uiPortEntry.port, 10);
+        if (!isNaN(numericPort)) {
+          if (numericPort >= 1 && numericPort <= 65535) {
+            k8sPort.port = numericPort;
+          } else {
+            console.warn(`[YamlGenSvc] Номер порта '${numericPort}' вне допустимого диапазона (1-65535), будет пропущен.`);
+             return null;
+          }
+        } else {
+          k8sPort.port = uiPortEntry.port;
+        }
+      }
+    }
+
+    if (Object.keys(k8sPort).length === 0) {
+      return null;
+    }
+
+    return k8sPort;
   }
 
-  public generateNetworkPolicyObject(): NetworkPolicy {
+  public createNetworkPolicyObject(
+    targetPodGroupId: string,
+    allNodes: Node<PodGroupNodeData | NamespaceNodeData>[],
+    allEdges: Edge[]
+  ): NetworkPolicy | null {
+    const targetNode = allNodes.find((node) => node.id === targetPodGroupId);
+
+    if (!targetNode) {
+      console.error(`[YamlGenSvc] Узел с ID '${targetPodGroupId}' не найден.`);
+      return null;
+    }
+
+    if (targetNode.type !== 'podGroup' || !isPodGroupNodeData(targetNode.data)) {
+      console.error(
+        `[YamlGenSvc] Узел '${targetPodGroupId}' не является PodGroup или его данные некорректны.`
+      );
+      return null;
+    }
+
+    const podGroupData: PodGroupNodeData = targetNode.data;
+
+    if (!podGroupData.metadata.namespace) {
+      console.error(
+        `[YamlGenSvc] У PodGroup '${podGroupData.metadata.name}' отсутствует неймспейс. Политика не может быть создана.`
+      );
+      return null;
+    }
+    
+    if (Object.keys(podGroupData.labels || {}).length === 0) {
+        console.warn(
+          `[YamlGenSvc] У PodGroup '${podGroupData.metadata.name}' нет лейблов. 'spec.podSelector' будет пустым (выберет все поды в неймспейсе).`
+        );
+    }
+
+    const policyName = `netpol-${podGroupData.metadata.name || targetPodGroupId.slice(-6)}`;
+
     const policy: NetworkPolicy = {
       apiVersion: 'networking.k8s.io/v1',
       kind: 'NetworkPolicy',
       metadata: {
-        name: this.generatePolicyName(),
+        name: policyName,
+        namespace: podGroupData.metadata.namespace,
       },
       spec: {
         podSelector: {
+          matchLabels: { ...(podGroupData.labels || {}) },
+        },
+      },
+    };
+
+    const policyTypesSet = new Set<PolicyType>();
+    if (podGroupData.policyConfig.defaultDenyIngress) policyTypesSet.add('Ingress');
+    if (podGroupData.policyConfig.defaultDenyEgress) policyTypesSet.add('Egress');
+
+    const createPeer = (
+      node: Node<PodGroupNodeData | NamespaceNodeData>,
+      targetNamespace: string
+    ): NetworkPolicyPeer | null => {
+      if (node.type === 'podGroup' && isPodGroupNodeData(node.data)) {
+        const peerPodData = node.data;
+        const peer: NetworkPolicyPeer = {
+          podSelector: { matchLabels: { ...(peerPodData.labels || {}) } },
+        };
+        if (
+          peerPodData.metadata.namespace &&
+          peerPodData.metadata.namespace !== targetNamespace
+        ) {
+          peer.namespaceSelector = {
+            matchLabels: { 'kubernetes.io/metadata.name': peerPodData.metadata.namespace },
+          };
+        }
+        return peer;
+      } else if (node.type === 'namespace' && node.data?.label) {
+        return {
+          namespaceSelector: { matchLabels: { 'kubernetes.io/metadata.name': node.data.label } },
+        };
+      }
+      return null;
+    };
+
+    const processPortsForEdge = (edgeData: Edge['data']): NetworkPolicyPort[] | undefined => {
+      const uiPorts = edgeData?.ports as PortProtocolEntry[] | undefined;
+      if (!uiPorts || uiPorts.length === 0) return undefined;
+
+      const k8sPorts: NetworkPolicyPort[] = [];
+      for (const uiPort of uiPorts) {
+        const k8sPort = this.transformUiPortToK8sPort(uiPort);
+        if (k8sPort) {
+          k8sPorts.push(k8sPort);
         }
       }
+      return k8sPorts.length > 0 ? k8sPorts : undefined;
     };
+
+    // --- Ingress ---
+    const ingressRules: NetworkPolicyIngressRule[] = [];
+    const incomingEdges = allEdges.filter(
+      (edge) => edge.target === targetPodGroupId && edge.type === 'customRuleEdge'
+    );
+    for (const edge of incomingEdges) {
+      const sourceNode = allNodes.find((node) => node.id === edge.source);
+      if (!sourceNode) continue;
+      const peer = createPeer(sourceNode, podGroupData.metadata.namespace);
+      if (peer) {
+        const rule: NetworkPolicyIngressRule = { from: [peer] };
+        const k8sPorts = processPortsForEdge(edge.data);
+        if (k8sPorts) rule.ports = k8sPorts;
+        ingressRules.push(rule);
+      }
+    }
+    if (ingressRules.length > 0) {
+      policy.spec.ingress = ingressRules;
+      policyTypesSet.add('Ingress');
+    }
+
+    // --- Egress ---
+    const egressRules: NetworkPolicyEgressRule[] = [];
+    const outgoingEdges = allEdges.filter(
+      (edge) => edge.source === targetPodGroupId && edge.type === 'customRuleEdge'
+    );
+    for (const edge of outgoingEdges) {
+      const destNode = allNodes.find((node) => node.id === edge.target);
+      if (!destNode) continue;
+      const peer = createPeer(destNode, podGroupData.metadata.namespace);
+      if (peer) {
+        const rule: NetworkPolicyEgressRule = { to: [peer] };
+        const k8sPorts = processPortsForEdge(edge.data);
+        if (k8sPorts) rule.ports = k8sPorts;
+        egressRules.push(rule);
+      }
+    }
+    if (egressRules.length > 0) {
+      policy.spec.egress = egressRules;
+      policyTypesSet.add('Egress');
+    }
+
+    if (policyTypesSet.size > 0) {
+      policy.spec.policyTypes = Array.from(policyTypesSet).sort();
+    }
+
     return policy;
   }
 
-  public generateYamlString(policyObject?: NetworkPolicy): string {
-    const objectToDump = policyObject || this.generateNetworkPolicyObject();
+  public generateYamlString(policyObject: NetworkPolicy | null): string {
+    if (!policyObject) {
+      return "# Ошибка: Объект NetworkPolicy не предоставлен для генерации YAML.";
+    }
     try {
-      return dump(objectToDump, { indent: 2, skipInvalid: true });
+      return dump(policyObject, { indent: 2, skipInvalid: true, sortKeys: false });
     } catch (e) {
-      console.error("Error generating YAML:", e);
-      return "Error generating YAML. Check console for details.";
+      console.error("[YamlGenSvc] Ошибка при генерации YAML:", e);
+      const errorMessage = e instanceof Error ? e.message : "Неизвестная ошибка";
+      return `# Ошибка генерации YAML: ${errorMessage}\n# Проверьте консоль для деталей.`;
     }
   }
 }

--- a/my-visual-editor/src/types/index.ts
+++ b/my-visual-editor/src/types/index.ts
@@ -5,38 +5,87 @@ export interface PortProtocolEntry {
 }
 
 export interface PodGroupNodeData {
-      label?: string;
-      labels: Record<string, string>;
-      metadata: {
-        name: string;
-        namespace: string;
-      };
-      policyConfig: {
-        defaultDenyIngress: boolean;
-        defaultDenyEgress: boolean;
-      };
-    }
+  label?: string;
+  labels: Record<string, string>;
+  metadata: {
+    name: string;
+    namespace: string;
+  };
+  policyConfig: {
+    defaultDenyIngress: boolean;
+    defaultDenyEgress: boolean;
+  };
+}
 
 export function isPodGroupNodeData(data: unknown): data is PodGroupNodeData {
   if (typeof data !== 'object' || data === null) {
     return false;
   }
-
   const d = data as Partial<PodGroupNodeData>;
-
   return (
     typeof d.metadata === 'object' && d.metadata !== null &&
     typeof d.metadata.name === 'string' &&
     typeof d.metadata.namespace === 'string' &&
-
     typeof d.policyConfig === 'object' && d.policyConfig !== null &&
     typeof d.policyConfig.defaultDenyIngress === 'boolean' &&
     typeof d.policyConfig.defaultDenyEgress === 'boolean' &&
-
     typeof d.labels === 'object' && d.labels !== null
   );
 }
 
 export interface NamespaceNodeData {
   label?: string;
+}
+
+export interface K8sLabelSelector {
+  matchLabels?: { [key: string]: string };
+}
+
+export interface IPBlock {
+  cidr: string;
+  except?: string[];
+}
+
+export interface NetworkPolicyPeer {
+  podSelector?: K8sLabelSelector;
+  namespaceSelector?: K8sLabelSelector;
+  ipBlock?: IPBlock;
+}
+
+export interface NetworkPolicyPort {
+  protocol?: 'TCP' | 'UDP' | 'SCTP';
+  port?: number | string;
+}
+
+export interface NetworkPolicyIngressRule {
+  from?: NetworkPolicyPeer[];
+  ports?: NetworkPolicyPort[];
+}
+
+export interface NetworkPolicyEgressRule {
+  to?: NetworkPolicyPeer[];
+  ports?: NetworkPolicyPort[];
+}
+
+export type PolicyType = 'Ingress' | 'Egress';
+
+export interface NetworkPolicySpec {
+  podSelector: K8sLabelSelector;
+  policyTypes?: PolicyType[];
+  ingress?: NetworkPolicyIngressRule[];
+  egress?: NetworkPolicyEgressRule[];
+}
+
+export interface NetworkPolicyMetadata {
+  name: string;
+  namespace?: string;
+  labels?: { [key: string]: string };
+  annotations?: { [key: string]: string };
+}
+
+export interface NetworkPolicy {
+  apiVersion: 'networking.k8s.io/v1';
+  kind: 'NetworkPolicy';
+  metadata: NetworkPolicyMetadata;
+  spec: NetworkPolicySpec;
 }


### PR DESCRIPTION
Implements core YAML generation for NetworkPolicies:
- Populates `spec.policyTypes` based on default deny flags and presence of ingress/egress rules.
- Generates `spec.ingress` and `spec.egress` sections from visual editor edges, determining rule type by edge direction.
- Adds `ports` to ingress/egress rules from edge data, handling 'any' port/protocol and specific port-protocol pairs.
- Fixes edge rendering issue where edges appeared under namespace nodes (CSS z-index adjustment).

Closes #10