### PR TITLE
feat: Implement palette and namespace node D&D

### DIFF
--- a/my-visual-editor/src/components/Canvas/Canvas.tsx
+++ b/my-visual-editor/src/components/Canvas/Canvas.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef } from 'react';
 import ReactFlow, {
   Node,
   Edge,
@@ -10,36 +10,86 @@ import ReactFlow, {
   MiniMap,
   Background,
   BackgroundVariant,
+  useReactFlow,
 } from 'reactflow';
 
 import 'reactflow/dist/style.css';
 
-const initialNodes: Node[] = [
-  { id: '1', position: { x: 0, y: 0 }, data: { label: 'Node 1' } },
-  { id: '2', position: { x: 0, y: 100 }, data: { label: 'Node 2' } },
-];
+import CustomNodeNamespace from '../nodes/CustomNodeNamespace';
 
-const initialEdges: Edge[] = [{ id: 'e1-2', source: '1', target: '2' }];
+const nodeTypes = {
+  namespace: CustomNodeNamespace,
+};
+
+let id = 0;
+const getId = () => `dndnode_${id++}`;
+
+const initialNodes: Node[] = [];
+const initialEdges: Edge[] = [];
 
 const Canvas: React.FC = () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars 
-  const [nodes, _setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
 
-  const onConnect = useCallback((params: Connection) => setEdges((eds) => addEdge(params, eds)), [setEdges]);
+  const reactFlowWrapper = useRef<HTMLDivElement>(null);
+
+  const { project } = useReactFlow();
+
+  const onConnect = useCallback(
+    (params: Connection | Edge) => setEdges((eds) => addEdge(params, eds)),
+    [setEdges],
+  );
+
+  const onDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const onDrop = useCallback(
+    (event: React.DragEvent) => {
+      event.preventDefault();
+
+      const type = event.dataTransfer.getData('application/reactflow');
+
+      if (typeof type === 'undefined' || !type || type !== 'namespace') {
+        return;
+      }
+
+      const reactFlowBounds = reactFlowWrapper.current!.getBoundingClientRect();
+      const position = project({
+        x: event.clientX - reactFlowBounds.left,
+        y: event.clientY - reactFlowBounds.top,
+      });
+
+      const newNode: Node = {
+        id: getId(),
+        type,
+        position,
+        data: { label: `${type} node` },
+      };
+
+      setNodes((nds) => nds.concat(newNode));
+    },
+    [project, setNodes],
+  );
 
   return (
-    <ReactFlow
-      nodes={nodes}
-      edges={edges}
-      onNodesChange={onNodesChange}
-      onEdgesChange={onEdgesChange}
-      onConnect={onConnect}
-      fitView>
-      <Controls />
-      <MiniMap />
-      <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
-    </ReactFlow>
+    <div className="reactflow-wrapper" ref={reactFlowWrapper} style={{ width: '100%', height: '100%' }}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+        nodeTypes={nodeTypes}
+        fitView>
+        <Controls />
+        <MiniMap />
+        <Background variant={BackgroundVariant.Dots} gap={12} size={1} />
+      </ReactFlow>
+    </div>
   );
 };
 

--- a/my-visual-editor/src/components/Palette/Palette.tsx
+++ b/my-visual-editor/src/components/Palette/Palette.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import './Palette.css';
+
+const Palette = () => {
+  const onDragStart = (event: React.DragEvent, nodeType: string) => {
+    event.dataTransfer.setData('application/reactflow', nodeType);
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
+  return (
+    <aside>
+      <div className="description">Можно перетаскивать эти узлы на рабочую область:</div>
+      <div className="dndnode" onDragStart={(event) => onDragStart(event, 'namespace')} draggable>
+        Неймспейс
+      </div>
+    </aside>
+  );
+};
+
+export default Palette;

--- a/my-visual-editor/src/components/nodes/CustomNodeNamespace.tsx
+++ b/my-visual-editor/src/components/nodes/CustomNodeNamespace.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Handle, Position } from 'reactflow';
+
+interface CustomNodeNamespaceData {
+  label?: string;
+}
+
+const CustomNodeNamespace: React.FC<{ data: CustomNodeNamespaceData }> = ({ data }) => {
+  return (
+    <div style={{
+      padding: '10px',
+      border: '1px solid #1a192b',
+      borderRadius: '5px',
+      backgroundColor: '#fff',
+      minWidth: '100px',
+      textAlign: 'center',
+    }}>
+      <div>{data.label || 'Неймспейс Узел'}</div>
+
+      <Handle type="target" position={Position.Top} />
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+};
+
+export default CustomNodeNamespace;

--- a/my-visual-editor/src/layout/Layout.css
+++ b/my-visual-editor/src/layout/Layout.css
@@ -4,7 +4,7 @@
   height: 100%;
 }
 
-.layout-palette {
+.layout-container aside {
   width: 200px;
   background-color: #f0f0f0;
   border-right: 1px solid #ccc;

--- a/my-visual-editor/src/layout/Layout.tsx
+++ b/my-visual-editor/src/layout/Layout.tsx
@@ -1,21 +1,26 @@
 import React from 'react';
+import { ReactFlowProvider } from 'reactflow';
 import Canvas from '../components/Canvas/Canvas';
+import Palette from '../components/Palette/Palette';
 import './Layout.css';
 
 const Layout: React.FC = () => {
   return (
     <div className="layout-container">
-      <div className="layout-palette">
-        <h2>Palette</h2>
-      </div>
+      <Palette />
+
       <div className="layout-main-area">
-        <div className="layout-canvas">
-          <Canvas />
-        </div>
+        <ReactFlowProvider>
+          <div className="layout-canvas">
+            <Canvas />
+          </div>
+        </ReactFlowProvider>
+
         <div className="layout-inspector">
           <h2>Inspector</h2>
         </div>
       </div>
+
       <div className="layout-output">
         <h2>Output</h2>
       </div>


### PR DESCRIPTION
This PR implements the drag-and-drop functionality for adding Namespace nodes from a new palette.

Key changes:
- Adds `Palette` component (`src/components/Palette/*`).
- Adds `CustomNodeNamespace` component (`src/components/nodes/*`).
- Enables D&D for 'Namespace' nodes from the palette.
- Implements canvas drop handling to create and add new nodes using `useReactFlow`.
- Registers the custom node type in `Canvas.tsx`.
- Integrates the `Palette` and wraps `Canvas` in `ReactFlowProvider` in `Layout.tsx`.
- Updates `Layout.css` for palette integration.

**How to test:**
Drag the 'Неймспейс' item from the left sidebar onto the main canvas area. A new custom node should appear at the drop location.

Closes #2